### PR TITLE
Support setting host field in Mapping at global, path and operation levels

### DIFF
--- a/docs/ambassador.md
+++ b/docs/ambassador.md
@@ -30,24 +30,25 @@ To override settings on the path or HTTP method level, you are required to use t
 
 ## Full Options Reference
 
-|           Name          |         CLI Option         | OpenAPI Spec x-kusk label |                                                    Descriptions                                                    | Overwritable at path / method  |
-|:-----------------------:|:--------------------------:|:-------------------------:|:------------------------------------------------------------------------------------------------------------------:|:------------------------------:|
-| OpenAPI or Swagger File |            --in            |            N/A            |                                  Location of the OpenAPI or Swagger specification                                  |                ❌               |
-|        Namespace        |         --namespace        |         namespace         |                         the namespace in which to create the generated resources (Required)                        |                ❌               |
-|       Service Name      |       --service.name       |        service.name       |                              the name of the service running in Kubernetes (Required)                              |                ❌               |
-|    Service Namespace    |     --service.namespace    |     service.namespace     |                    The namespace where the service named above resides (default value: default)                    |                ❌               |
-|       Service Port      |       --service.port       |        service.port       |                                Port the service is listening on (default value: 80)                                |                ❌               |
-|        Path Base        |         --path.base        |         path.base         |                                           Prefix for your resource routes                                          |                ❌               |
-|     Path Trim Prefix    |     --path.trim_prefix     |      path.trim_prefix     |                       Trim the specified prefix from URl before passing request onto service                       |                ❌               |
-|        Path split       |        --path.split        |         path.split        |                   Boolean; whether or not to force generator to generate a mapping for each path                   |                ❌               |
-|     Request Timeout     | --timeouts.request_timeout |  timeouts.request_timeout |                                           Total request timeout (seconds)                                          |                ✅               |
-|       Idle Timeout      |   --timeouts.idle_timeout  |   timeouts.idle_timeout   |                                          Idle connection timeout (seconds)                                         |                ✅               |
-|       CORS Origins      |             N/A            |        cors.origins       |                                                  Array of origins                                                  |                ✅               |
-|       CORS Methods      |             N/A            |        cors.methods       |                                                  Array of methods                                                  |                ✅               |
-|       CORS Headers      |             N/A            |        cors.headers       |                                                  Array of headers                                                  |                ✅               |
-|    CORS ExposeHeaders   |             N/A            |    cors.expose_headers    |                                             Array of headers to expose                                             |                ✅               |
-|     CORS Credentials    |             N/A            |      cors.credentials     |                                 Boolean: enable credentials (default value: false)                                 |                ✅               |
-|       CORS Max Age      |             N/A            |        cors.max_age       | Integer:how long the response to the preflight request can be cached for without sending another preflight request |                ✅               |
+| Name                    | CLI Option                 | OpenAPI Spec x-kusk label | Descriptions                                                                                                       | Overwritable at path / method |
+|-------------------------|----------------------------|---------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| OpenAPI or Swagger File | --in                       | N/A                       | Location of the OpenAPI or Swagger specification                                                                   | ❌                             |
+| Namespace               | --namespace                | namespace                 | the namespace in which to create the generated resources (Required)                                                | ❌                             |
+| Service Name            | --service.name             | service.name              | the name of the service running in Kubernetes (Required)                                                           | ❌                             |
+| Service Namespace       | --service.namespace        | service.namespace         | The namespace where the service named above resides (default value: default)                                       | ❌                             |
+| Service Port            | --service.port             | service.port              | Port the service is listening on (default value: 80)                                                               | ❌                             |
+| Path Base               | --path.base                | path.base                 | Prefix for your resource routes                                                                                    | ❌                             |
+| Path Trim Prefix        | --path.trim_prefix         | path.trim_prefix          | Trim the specified prefix from URl before passing request onto service                                             | ❌                             |
+| Path split              | --path.split               | path.split                | Boolean; whether or not to force generator to generate a mapping for each path                                     | ❌                             |
+| Host                    | --host                     | host                      | The value to set the host field to in the Mapping resource                                                         | ✅                             |
+| Request Timeout         | --timeouts.request_timeout | timeouts.request_timeout  | Total request timeout (seconds)                                                                                    | ✅                             |
+| Idle Timeout            | --timeouts.idle_timeout    | timeouts.idle_timeout     | Idle connection timeout (seconds)                                                                                  | ✅                             |
+| CORS Origins            | N/A                        | cors.origins              | Array of origins                                                                                                   | ✅                             |
+| CORS Methods            | N/A                        | cors.methods              | Array of methods                                                                                                   | ✅                             |
+| CORS Headers            | N/A                        | cors.headers              | Array of headers                                                                                                   | ✅                             |
+| CORS ExposeHeaders      | N/A                        | cors.expose_headers       | Array of headers to expose                                                                                         | ✅                             |
+| CORS Credentials        | N/A                        | cors.credentials          | Boolean: enable credentials (default value: false)                                                                 | ✅                             |
+| CORS Max Age            | N/A                        | cors.max_age              | Integer:how long the response to the preflight request can be cached for without sending another preflight request | ✅                             |
 
 ## Basic Usage
 
@@ -257,6 +258,56 @@ metadata:
   namespace: my-namespace
 spec:
   prefix: "/"
+  service: booksapp.my-service-namespace:7000
+  rewrite: ""
+  timeout_ms: 120000
+  idle_timeout_ms: 120000
+```
+
+## Setting the Host header
+
+kusk allows for setting both idle and request timeouts via flags or the x-kusk OpenAPI extension
+
+### CLI Flags
+
+```shell
+kusk ambassador -i examples/booksapp/booksapp.yaml \
+--namespace my-namespace \
+--service.name booksapp \
+--service.port 7000 \
+--service.namespace my-service-namespace \
+--host "somehost.io"
+```
+
+### OpenAPI Specification
+
+```yaml
+openapi: 3.0.1
+x-kusk:
+  namespace: booksapp
+  service:
+    name: webapp
+    namespace: booksapp
+    port: 7000
+  host: somehost.io
+paths:
+  /:
+    get: {}
+...
+```
+
+### Sample Output
+
+```yaml
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: booksapp
+  namespace: my-namespace
+spec:
+  prefix: "/"
+  host: somehost.io
   service: booksapp.my-service-namespace:7000
   rewrite: ""
   timeout_ms: 120000

--- a/generators/ambassador/ambassador.go
+++ b/generators/ambassador/ambassador.go
@@ -140,7 +140,7 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 					Method:           method,
 					Path:             mappingPath,
 					Regex:            regex,
-					Host:             opts.Host,
+					Host:             host,
 				}
 
 				var corsOpts options.CORSOptions

--- a/generators/ambassador/ambassador_test.go
+++ b/generators/ambassador/ambassador_test.go
@@ -1224,4 +1224,46 @@ spec:
   idle_timeout_ms 43000
 `,
 	},
+	{
+		name: "host path set",
+		options: options.Options{
+			Namespace: "default",
+			Service: options.ServiceOptions{
+				Namespace: "default",
+				Name:      "petstore",
+			},
+			Host: "somehost.io",
+		},
+		spec: `
+openapi: 3.0.2
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  version: 1.0.5
+x-kusk:
+  namespace: notdefault
+  service:
+    name: petstore
+  host: somehost.io
+paths:
+  "/pet":
+    put:
+      operationId: updatePet
+      responses:
+        '200':
+          description: Successful operation
+`,
+		res: `
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: petstore
+  namespace: default
+spec:
+  prefix: "/"
+  host: somehost.io
+  service: petstore.default:80
+  rewrite: ""
+`,
+	},
 }

--- a/generators/ambassador/template.go
+++ b/generators/ambassador/template.go
@@ -24,6 +24,9 @@ type mappingTemplateData struct {
 	Regex   bool
 	Rewrite bool
 
+	Host string
+	HostRegex bool
+
 	CORSEnabled bool
 
 	CORS corsTemplateData
@@ -44,6 +47,10 @@ spec:
 
   {{if .Regex}}
   prefix_regex: true
+  {{end}}
+
+  {{ if .Host}}
+  host: {{.Host}}
   {{end}}
 
   {{if .Method}}

--- a/options/options.go
+++ b/options/options.go
@@ -9,6 +9,7 @@ import (
 type SubOptions struct {
 	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 
+	Host string `yaml:"host,omitempty" json:"host,omitempty"`
 	CORS     CORSOptions    `yaml:"cors,omitempty" json:"cors,omitempty"`
 	Timeouts TimeoutOptions `yaml:"timeouts,omitempty" json:"timeouts,omitempty"`
 }


### PR DESCRIPTION
This PR resolves #88 

## Changes

- Update Ambassador generator to support setting Host field in Mapping
- Add Host option to SubOptions struct so it can be overwritten at the path and operation levels
- Add documentation for host field

## Verify
- Spin up local k3s cluster
- Install Ambassador (see petstore example for Ambassador)
- Install one of the examples
- Add the host key to the kusk extension for one of the examples like so:
```
...
x-kusk:
    ...
    host: somehost.io
    ...
...
```
- Generate ambassador mappings
- `curl -kLi -H 'Host: somehost.io' https://localhost:8443/`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
