### PR TITLE
Split Wizard up into testable components

### DIFF
--- a/cmd/wizard.go
+++ b/cmd/wizard.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubeshop/kusk/spec"
 	"github.com/kubeshop/kusk/wizard"
+	"github.com/kubeshop/kusk/wizard/prompt"
 )
 
 func init() {
@@ -28,7 +29,7 @@ func init() {
 				log.Fatal(err)
 			}
 
-			wizard.Start(apiSpecPath, apiSpec)
+			wizard.Start(apiSpecPath, apiSpec, prompt.New())
 		},
 	}
 

--- a/wizard/flow/ambassador.go
+++ b/wizard/flow/ambassador.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kubeshop/kusk/generators/ambassador"
 	"github.com/kubeshop/kusk/options"
-	"github.com/kubeshop/kusk/wizard/prompt"
 )
 
 type ambassadorFlow struct {
@@ -18,13 +17,13 @@ func (a ambassadorFlow) Start() (Response, error) {
 		basePathSuggestions = append(basePathSuggestions, server.URL)
 	}
 
-	basePath := prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
-	trimPrefix := prompt.InputNonEmpty("Prefix to trim from the URL (rewrite)", basePath)
+	basePath := a.prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
+	trimPrefix := a.prompt.InputNonEmpty("Prefix to trim from the URL (rewrite)", basePath)
 
 	separateMappings := false
 
 	if basePath != "" {
-		separateMappings = prompt.Confirm("Generate mapping for each endpoint separately?")
+		separateMappings = a.prompt.Confirm("Generate mapping for each endpoint separately?")
 	}
 
 	opts := &options.Options{
@@ -61,6 +60,6 @@ func (a ambassadorFlow) Start() (Response, error) {
 
 	return Response{
 		EquivalentCmd: cmd,
-		Manifests: mappings,
+		Manifests:     mappings,
 	}, nil
 }

--- a/wizard/flow/ambassador.go
+++ b/wizard/flow/ambassador.go
@@ -1,0 +1,66 @@
+package flow
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/kusk/generators/ambassador"
+	"github.com/kubeshop/kusk/options"
+	"github.com/kubeshop/kusk/wizard/prompt"
+)
+
+type ambassadorFlow struct {
+	baseFlow
+}
+
+func (a ambassadorFlow) Start() (Response, error) {
+	var basePathSuggestions []string
+	for _, server := range a.apiSpec.Servers {
+		basePathSuggestions = append(basePathSuggestions, server.URL)
+	}
+
+	basePath := prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
+	trimPrefix := prompt.InputNonEmpty("Prefix to trim from the URL (rewrite)", basePath)
+
+	separateMappings := false
+
+	if basePath != "" {
+		separateMappings = prompt.Confirm("Generate mapping for each endpoint separately?")
+	}
+
+	opts := &options.Options{
+		Namespace: a.targetNamespace,
+		Service: options.ServiceOptions{
+			Namespace: a.targetNamespace,
+			Name:      a.targetService,
+		},
+		Path: options.PathOptions{
+			Base:       basePath,
+			TrimPrefix: trimPrefix,
+			Split:      separateMappings,
+		},
+	}
+
+	cmd := fmt.Sprintf("kusk ambassador -i %s ", a.apiSpecPath)
+	cmd = cmd + fmt.Sprintf("--namespace=%s ", a.targetNamespace)
+	cmd = cmd + fmt.Sprintf("--service.namespace=%s ", a.targetNamespace)
+	cmd = cmd + fmt.Sprintf("--service.name=%s ", a.targetService)
+	cmd = cmd + fmt.Sprintf("--path.base=%s ", basePath)
+	if trimPrefix != "" {
+		cmd = cmd + fmt.Sprintf("--path.trim_prefix=%s ", trimPrefix)
+	}
+	if separateMappings {
+		cmd = cmd + fmt.Sprintf("--path.split ")
+	}
+
+	var ag ambassador.Generator
+
+	mappings, err := ag.Generate(opts, a.apiSpec)
+	if err != nil {
+		return Response{}, fmt.Errorf("Failed to generate mappings: %s\n", err)
+	}
+
+	return Response{
+		EquivalentCmd: cmd,
+		Manifests: mappings,
+	}, nil
+}

--- a/wizard/flow/flow.go
+++ b/wizard/flow/flow.go
@@ -1,0 +1,55 @@
+package flow
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+type Interface interface {
+	Start() (Response, error)
+}
+
+type Response struct {
+	EquivalentCmd string
+	Manifests string
+}
+
+// Flows "inherit" from this
+type baseFlow struct {
+	apiSpecPath string
+	apiSpec *openapi3.T
+	targetNamespace string
+	targetService string
+}
+
+type Args struct {
+	Service string
+
+	ApiSpecPath string
+	ApiSpec *openapi3.T
+	TargetNamespace string
+	TargetService string
+}
+
+// New returns a new flow based on the args.Service
+// returns an error if the service isn't supported by a flow
+func New(args *Args) (Interface, error) {
+	baseFlow := baseFlow{
+		apiSpecPath:     args.ApiSpecPath,
+		apiSpec:         args.ApiSpec,
+		targetNamespace: args.TargetNamespace,
+		targetService:   args.TargetService,
+	}
+
+	switch args.Service {
+	case "ambassador":
+		return ambassadorFlow{baseFlow}, nil
+	case "linkerd":
+		return linkerdFlow{baseFlow}, nil
+	case "nginx-ingress":
+		return nginxIngressFlow{baseFlow}, nil
+	default:
+		return nil, fmt.Errorf("unsupported service: %s\n", args.Service)
+	}
+}

--- a/wizard/flow/flow.go
+++ b/wizard/flow/flow.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/kubeshop/kusk/wizard/prompt"
 )
 
 type Interface interface {
@@ -12,24 +14,28 @@ type Interface interface {
 
 type Response struct {
 	EquivalentCmd string
-	Manifests string
+	Manifests     string
 }
 
 // Flows "inherit" from this
 type baseFlow struct {
-	apiSpecPath string
-	apiSpec *openapi3.T
+	apiSpecPath     string
+	apiSpec         *openapi3.T
 	targetNamespace string
-	targetService string
+	targetService   string
+
+	prompt prompt.Prompter
 }
 
 type Args struct {
 	Service string
 
-	ApiSpecPath string
-	ApiSpec *openapi3.T
+	ApiSpecPath     string
+	ApiSpec         *openapi3.T
 	TargetNamespace string
-	TargetService string
+	TargetService   string
+
+	Prompt prompt.Prompter
 }
 
 // New returns a new flow based on the args.Service
@@ -40,6 +46,7 @@ func New(args *Args) (Interface, error) {
 		apiSpec:         args.ApiSpec,
 		targetNamespace: args.TargetNamespace,
 		targetService:   args.TargetService,
+		prompt:          args.Prompt,
 	}
 
 	switch args.Service {

--- a/wizard/flow/linkerd.go
+++ b/wizard/flow/linkerd.go
@@ -1,0 +1,46 @@
+package flow
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/kusk/generators/linkerd"
+	"github.com/kubeshop/kusk/options"
+	"github.com/kubeshop/kusk/wizard/prompt"
+)
+
+type linkerdFlow struct {
+	baseFlow
+}
+
+func (l linkerdFlow) Start() (Response, error) {
+	clusterDomain := prompt.InputNonEmpty("Cluster domain", "cluster.local")
+
+	opts := &options.Options{
+		Namespace: l.targetNamespace,
+		Service: options.ServiceOptions{
+			Namespace: l.targetNamespace,
+			Name:      l.targetService,
+		},
+		Cluster: options.ClusterOptions{
+			ClusterDomain: clusterDomain,
+		},
+	}
+
+	cmd := fmt.Sprintf("kusk linkerd -i %s ", l.apiSpecPath)
+	cmd = cmd + fmt.Sprintf("--namespace=%s ", l.targetNamespace)
+	cmd = cmd + fmt.Sprintf("--service.namespace=%s ", l.targetNamespace)
+	cmd = cmd + fmt.Sprintf("--service.name=%s ", l.targetService)
+	cmd = cmd + fmt.Sprintf("--cluster.cluster_domain=%s ", clusterDomain)
+
+	var ld linkerd.Generator
+
+	serviceProfiles, err := ld.Generate(opts, l.apiSpec)
+	if err != nil {
+		return Response{}, fmt.Errorf("failed to generate linkerd service profiles: %s\n", err)
+	}
+
+	return Response{
+		EquivalentCmd: cmd,
+		Manifests:     serviceProfiles,
+	}, nil
+}

--- a/wizard/flow/linkerd.go
+++ b/wizard/flow/linkerd.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kubeshop/kusk/generators/linkerd"
 	"github.com/kubeshop/kusk/options"
-	"github.com/kubeshop/kusk/wizard/prompt"
 )
 
 type linkerdFlow struct {
@@ -13,7 +12,7 @@ type linkerdFlow struct {
 }
 
 func (l linkerdFlow) Start() (Response, error) {
-	clusterDomain := prompt.InputNonEmpty("Cluster domain", "cluster.local")
+	clusterDomain := l.prompt.InputNonEmpty("Cluster domain", "cluster.local")
 
 	opts := &options.Options{
 		Namespace: l.targetNamespace,

--- a/wizard/flow/nginx_ingress.go
+++ b/wizard/flow/nginx_ingress.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kubeshop/kusk/generators/nginx_ingress"
 	"github.com/kubeshop/kusk/options"
-	"github.com/kubeshop/kusk/wizard/prompt"
 )
 
 type nginxIngressFlow struct {
@@ -19,12 +18,12 @@ func (n nginxIngressFlow) Start() (Response, error) {
 		basePathSuggestions = append(basePathSuggestions, server.URL)
 	}
 
-	basePath := prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
-	trimPrefix := prompt.Input("Prefix to trim from the URL (rewrite)", "")
+	basePath := n.prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
+	trimPrefix := n.prompt.Input("Prefix to trim from the URL (rewrite)", "")
 
 	separateMappings := false
 	if basePath != "" {
-		separateMappings = prompt.Confirm("Generate ingress resource for each endpoint separately?")
+		separateMappings = n.prompt.Confirm("Generate ingress resource for each endpoint separately?")
 	}
 
 	opts := &options.Options{

--- a/wizard/flow/nginx_ingress.go
+++ b/wizard/flow/nginx_ingress.go
@@ -1,0 +1,68 @@
+package flow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubeshop/kusk/generators/nginx_ingress"
+	"github.com/kubeshop/kusk/options"
+	"github.com/kubeshop/kusk/wizard/prompt"
+)
+
+type nginxIngressFlow struct {
+	baseFlow
+}
+
+func (n nginxIngressFlow) Start() (Response, error) {
+	var basePathSuggestions []string
+	for _, server := range n.apiSpec.Servers {
+		basePathSuggestions = append(basePathSuggestions, server.URL)
+	}
+
+	basePath := prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
+	trimPrefix := prompt.Input("Prefix to trim from the URL (rewrite)", "")
+
+	separateMappings := false
+	if basePath != "" {
+		separateMappings = prompt.Confirm("Generate ingress resource for each endpoint separately?")
+	}
+
+	opts := &options.Options{
+		Namespace: n.targetNamespace,
+		Service: options.ServiceOptions{
+			Namespace: n.targetNamespace,
+			Name:      n.targetService,
+		},
+		Path: options.PathOptions{
+			Base:       basePath,
+			TrimPrefix: trimPrefix,
+			Split:      separateMappings,
+		},
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("kusk ambassador -i %s ", n.apiSpecPath))
+	sb.WriteString(fmt.Sprintf("--namespace=%s ", n.targetNamespace))
+	sb.WriteString(fmt.Sprintf("--service.namespace=%s ", n.targetNamespace))
+	sb.WriteString(fmt.Sprintf("--service.name=%s ", n.targetService))
+	sb.WriteString(fmt.Sprintf("--path.base=%s ", basePath))
+
+	if trimPrefix != "" {
+		sb.WriteString(fmt.Sprintf("--path.trim_prefix=%s ", trimPrefix))
+	}
+
+	if separateMappings {
+		sb.WriteString("--path.split ")
+	}
+
+	var ingressGenerator nginx_ingress.Generator
+	ingresses, err := ingressGenerator.Generate(opts, n.apiSpec)
+	if err != nil {
+		return Response{}, fmt.Errorf("Failed to generate ingresses: %s\n", err)
+	}
+
+	return Response{
+		EquivalentCmd: sb.String(),
+		Manifests:     ingresses,
+	}, nil
+}

--- a/wizard/prompt/prompt.go
+++ b/wizard/prompt/prompt.go
@@ -8,10 +8,24 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-func SelectOneOf(label string, variants []string, withAdd bool) string {
+type Prompter interface {
+	SelectOneOf(label string, variants []string, withAdd bool) string
+	Input(label, defaultString string) string
+	InputNonEmpty(label, defaultString string) string
+	FilePath(label, defaultPath string, shouldExist bool) string
+	Confirm(question string) bool
+}
+
+type prompter struct{}
+
+func New() Prompter {
+	return prompter{}
+}
+
+func (pr prompter) SelectOneOf(label string, variants []string, withAdd bool) string {
 	if len(variants) == 0 {
 		// it's better to show a prompt
-		return InputNonEmpty(label, "")
+		return pr.InputNonEmpty(label, "")
 	}
 
 	if withAdd {
@@ -35,7 +49,7 @@ func SelectOneOf(label string, variants []string, withAdd bool) string {
 	return res
 }
 
-func Input(label, defaultString string) string {
+func (_ prompter) Input(label, defaultString string) string {
 	p := promptui.Prompt{
 		Label:  label,
 		Stdout: os.Stderr,
@@ -50,7 +64,7 @@ func Input(label, defaultString string) string {
 	return res
 }
 
-func InputNonEmpty(label, defaultString string) string {
+func (_ prompter) InputNonEmpty(label, defaultString string) string {
 	p := promptui.Prompt{
 		Label:  label,
 		Stdout: os.Stderr,
@@ -69,7 +83,7 @@ func InputNonEmpty(label, defaultString string) string {
 	return res
 }
 
-func FilePath(label, defaultPath string, shouldExist bool) string {
+func (_ prompter) FilePath(label, defaultPath string, shouldExist bool) string {
 	p := promptui.Prompt{
 		Label:   label,
 		Stdout:  os.Stderr,
@@ -96,7 +110,7 @@ func FilePath(label, defaultPath string, shouldExist bool) string {
 	return res
 }
 
-func Confirm(question string) bool {
+func (_ prompter) Confirm(question string) bool {
 	p := promptui.Prompt{
 		Label:     question,
 		Stdout:    os.Stderr,

--- a/wizard/prompt/prompt.go
+++ b/wizard/prompt/prompt.go
@@ -116,9 +116,5 @@ func Confirm(question string) bool {
 func fileExists(path string) bool {
 	// check if file exists
 	f, err := os.Stat(path)
-	if err == nil && !f.IsDir() {
-		return true
-	}
-
-	return false
+	return err == nil && !f.IsDir()
 }

--- a/wizard/prompt/prompt.go
+++ b/wizard/prompt/prompt.go
@@ -1,0 +1,124 @@
+package prompt
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+)
+
+func SelectOneOf(label string, variants []string, withAdd bool) string {
+	if len(variants) == 0 {
+		// it's better to show a prompt
+		return InputNonEmpty(label, "")
+	}
+
+	if withAdd {
+		p := promptui.SelectWithAdd{
+			Label:  label,
+			Stdout: os.Stderr,
+			Items:  variants,
+		}
+
+		_, res, _ := p.Run()
+		return res
+	}
+
+	p := promptui.Select{
+		Label:  label,
+		Stdout: os.Stderr,
+		Items:  variants,
+	}
+
+	_, res, _ := p.Run()
+	return res
+}
+
+func Input(label, defaultString string) string {
+	p := promptui.Prompt{
+		Label:  label,
+		Stdout: os.Stderr,
+		Validate: func(s string) error {
+			return nil
+		},
+		Default: defaultString,
+	}
+
+	res, _ := p.Run()
+
+	return res
+}
+
+func InputNonEmpty(label, defaultString string) string {
+	p := promptui.Prompt{
+		Label:  label,
+		Stdout: os.Stderr,
+		Validate: func(s string) error {
+			if strings.TrimSpace(s) == "" {
+				return errors.New("should not be empty")
+			}
+
+			return nil
+		},
+		Default: defaultString,
+	}
+
+	res, _ := p.Run()
+
+	return res
+}
+
+func FilePath(label, defaultPath string, shouldExist bool) string {
+	p := promptui.Prompt{
+		Label:   label,
+		Stdout:  os.Stderr,
+		Default: defaultPath,
+		Validate: func(fp string) error {
+			if strings.TrimSpace(fp) == "" {
+				return errors.New("should not be empty")
+			}
+
+			if !shouldExist {
+				return nil
+			}
+
+			if fileExists(fp) {
+				return nil
+			}
+
+			return errors.New("should be an existing file")
+		},
+	}
+
+	res, _ := p.Run()
+
+	return res
+}
+
+func Confirm(question string) bool {
+	p := promptui.Prompt{
+		Label:     question,
+		Stdout:    os.Stderr,
+		IsConfirm: true,
+	}
+
+	_, err := p.Run()
+	if err != nil {
+		if errors.Is(err, promptui.ErrAbort) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func fileExists(path string) bool {
+	// check if file exists
+	f, err := os.Stat(path)
+	if err == nil && !f.IsDir() {
+		return true
+	}
+
+	return false
+}

--- a/wizard/wizard.go
+++ b/wizard/wizard.go
@@ -298,9 +298,5 @@ func flowNginxIngress(apiSpecPath string, apiSpec *openapi3.T, targetNamespace, 
 func fileExists(path string) bool {
 	// check if file exists
 	f, err := os.Stat(path)
-	if err == nil && !f.IsDir() {
-		return true
-	}
-
-	return false
+	return err == nil && !f.IsDir()
 }


### PR DESCRIPTION
As the Wizard is a core part of onboarding new users to Kusk and therefore it should be well written and tested to increase confidence when releasing it.

This PR splits the wizard up into smaller components that we can test in isolation / mock where the real thing isn't required

## Changes

- create internal wizard prompt package with a default implementation of a prompter interface. The idea behind this is that we can't use the promptui package in tests because a) it logs to stdout b) requires an interactive stdin session. This way we can mock a test prompter in the tests and have it return set values
- Each generator now has a dedicated flow and the wizard itself simply fetches the flows and runs them without calling a specifically named function like `flowAmbassador`. This separates concerns as now the wizard doesn't need to care about what flow to run, it hands that off to another component.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
