### PR TITLE
docs: fixed ga tag and workflow trigger

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
 
 jobs:
   deploy:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,8 +9,6 @@ edit_uri: blob/main/docs/
 theme:
   name: material
   locale: en
-  analytics:
-    gtag: G-GJSMW2FLG0
   highlightjs: true
   hljs_languages:
     - yaml
@@ -27,6 +25,11 @@ nav:
     - Nginx-Ingress: nginx-ingress.md
 
   - For Developers: development.md
+
+extra:
+  analytics:
+    provider: google
+    property: UA-204665550-4
 
 copyright: Copyright &copy; 2021 <a href="https://kubeshop.io">Kubeshop</a>
 


### PR DESCRIPTION
This PR fixes the GA tag used and fixes the github workflow to trigger documentation update when only mkdocs.yml changes
