### PR TITLE
Support Base path in Linkerd wizard and Support timeouts in Ambassador wizard

### DIFF
--- a/generators/ambassador/ambassador.go
+++ b/generators/ambassador/ambassador.go
@@ -209,8 +209,7 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 			TrimPrefix:       opts.Path.TrimPrefix,
 			RequestTimeout:   opts.Timeouts.RequestTimeout * 1000,
 			IdleTimeout:      opts.Timeouts.IdleTimeout * 1000,
-			Host: opts.Host,
-
+			Host:             opts.Host,
 		}
 
 		// if global CORS options are defined, take them

--- a/generators/ambassador/template.go
+++ b/generators/ambassador/template.go
@@ -24,7 +24,7 @@ type mappingTemplateData struct {
 	Regex   bool
 	Rewrite bool
 
-	Host string
+	Host      string
 	HostRegex bool
 
 	CORSEnabled bool

--- a/options/options.go
+++ b/options/options.go
@@ -9,7 +9,7 @@ import (
 type SubOptions struct {
 	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 
-	Host string `yaml:"host,omitempty" json:"host,omitempty"`
+	Host     string         `yaml:"host,omitempty" json:"host,omitempty"`
 	CORS     CORSOptions    `yaml:"cors,omitempty" json:"cors,omitempty"`
 	Timeouts TimeoutOptions `yaml:"timeouts,omitempty" json:"timeouts,omitempty"`
 }

--- a/wizard/flow/linkerd.go
+++ b/wizard/flow/linkerd.go
@@ -14,8 +14,13 @@ type linkerdFlow struct {
 func (l linkerdFlow) Start() (Response, error) {
 	clusterDomain := l.prompt.InputNonEmpty("Cluster domain", "cluster.local")
 
+	basePath := l.prompt.InputNonEmpty("Base Path", "/")
+
 	opts := &options.Options{
 		Namespace: l.targetNamespace,
+		Path: options.PathOptions{
+			Base: basePath,
+		},
 		Service: options.ServiceOptions{
 			Namespace: l.targetNamespace,
 			Name:      l.targetService,
@@ -29,6 +34,7 @@ func (l linkerdFlow) Start() (Response, error) {
 	cmd = cmd + fmt.Sprintf("--namespace=%s ", l.targetNamespace)
 	cmd = cmd + fmt.Sprintf("--service.namespace=%s ", l.targetNamespace)
 	cmd = cmd + fmt.Sprintf("--service.name=%s ", l.targetService)
+	cmd = cmd + fmt.Sprintf("--path.base=%s ", basePath)
 	cmd = cmd + fmt.Sprintf("--cluster.cluster_domain=%s ", clusterDomain)
 
 	var ld linkerd.Generator

--- a/wizard/flow/linkerd.go
+++ b/wizard/flow/linkerd.go
@@ -14,7 +14,12 @@ type linkerdFlow struct {
 func (l linkerdFlow) Start() (Response, error) {
 	clusterDomain := l.prompt.InputNonEmpty("Cluster domain", "cluster.local")
 
-	basePath := l.prompt.InputNonEmpty("Base Path", "/")
+	var basePathSuggestions []string
+	for _, server := range l.apiSpec.Servers {
+		basePathSuggestions = append(basePathSuggestions, server.URL)
+	}
+
+	basePath := l.prompt.SelectOneOf("Base path prefix", basePathSuggestions, true)
 
 	opts := &options.Options{
 		Namespace: l.targetNamespace,


### PR DESCRIPTION
This PR adds support to the Linkerd wizard for setting the base path prefix.

This PR also adds support to the Ambassador wizard for setting both request and idle timeouts

resolves #81

## Changes

- Add path.base support to Linkerd wizard
- Add timeouts.request_timeout and timeouts.idle_timeout support to Ambassador wizard
- Go fmt those files that were unformatted


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
