### PR TITLE
nginx-ingress: fix incorrect host command line option

### DIFF
--- a/generators/nginx_ingress/nginx_ingress.go
+++ b/generators/nginx_ingress/nginx_ingress.go
@@ -64,7 +64,7 @@ func (g *Generator) Flags() *pflag.FlagSet {
 	)
 
 	fs.String(
-		"ingress.host",
+		"host",
 		"",
 		"an Ingress Host to listen on",
 	)


### PR DESCRIPTION
## Changes

-

## Fixes

fixes incorrect host command line option

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
