### PR TITLE
CORS options support in Wizard

### DIFF
--- a/wizard/flow/ambassador.go
+++ b/wizard/flow/ambassador.go
@@ -46,6 +46,34 @@ func (a ambassadorFlow) Start() (Response, error) {
 		}
 	}
 
+	var corsOpts options.CORSOptions
+	if setCORS := a.prompt.Confirm("Set CORS options?"); setCORS {
+		// Origins
+		corsOpts.Origins = a.prompt.InputMany("add CORS origin")
+
+		// Methods
+		corsOpts.Methods = a.prompt.InputMany("add CORS method")
+
+		// Headers
+		corsOpts.Headers = a.prompt.InputMany("add CORS header")
+
+		// ExposeHeaders
+		corsOpts.ExposeHeaders = a.prompt.InputMany("add CORS headers you want to expose")
+
+		// Credentials
+		credentials := a.prompt.Confirm("enable CORS credentials")
+		corsOpts.Credentials = &credentials
+
+		// Max age
+		maxAgeStr := a.prompt.Input("set CORS max age", "0")
+		maxAge, err := strconv.Atoi(maxAgeStr)
+		if err != nil {
+			log.Printf("WARN: %s is not a valid max age value. Skipping\n", maxAgeStr)
+			maxAge = 0
+		}
+		corsOpts.MaxAge = maxAge
+	}
+
 	opts := &options.Options{
 		Namespace: a.targetNamespace,
 		Service: options.ServiceOptions{
@@ -58,6 +86,7 @@ func (a ambassadorFlow) Start() (Response, error) {
 			TrimPrefix: trimPrefix,
 			Split:      separateMappings,
 		},
+		CORS: corsOpts,
 	}
 
 	cmd := fmt.Sprintf("kusk ambassador -i %s ", a.apiSpecPath)

--- a/wizard/flow/nginx_ingress.go
+++ b/wizard/flow/nginx_ingress.go
@@ -39,6 +39,34 @@ func (n nginxIngressFlow) Start() (Response, error) {
 		}
 	}
 
+	var corsOpts options.CORSOptions
+	if setCORS := n.prompt.Confirm("Set CORS options?"); setCORS {
+		// Origins
+		corsOpts.Origins = []string{n.prompt.Input("add CORS origin", "")}
+
+		// Methods
+		corsOpts.Methods = n.prompt.InputMany("add CORS method")
+
+		// Headers
+		corsOpts.Headers = n.prompt.InputMany("add CORS header")
+
+		// ExposeHeaders
+		corsOpts.ExposeHeaders = n.prompt.InputMany("add CORS headers you want to expose")
+
+		// Credentials
+		credentials := n.prompt.Confirm("enable CORS credentials")
+		corsOpts.Credentials = &credentials
+
+		// Max age
+		maxAgeStr := n.prompt.Input("set CORS max age", "0")
+		maxAge, err := strconv.Atoi(maxAgeStr)
+		if err != nil {
+			log.Printf("WARN: %s is not a valid max age value. Skipping\n", maxAgeStr)
+			maxAge = 0
+		}
+		corsOpts.MaxAge = maxAge
+	}
+
 	opts := &options.Options{
 		Namespace: n.targetNamespace,
 		Service: options.ServiceOptions{
@@ -51,6 +79,7 @@ func (n nginxIngressFlow) Start() (Response, error) {
 			Split:      separateMappings,
 		},
 		Timeouts: timeoutOptions,
+		CORS:     corsOpts,
 	}
 
 	var sb strings.Builder

--- a/wizard/prompt/prompt.go
+++ b/wizard/prompt/prompt.go
@@ -2,6 +2,7 @@ package prompt
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -12,6 +13,7 @@ type Prompter interface {
 	SelectOneOf(label string, variants []string, withAdd bool) string
 	Input(label, defaultString string) string
 	InputNonEmpty(label, defaultString string) string
+	InputMany(label string) []string
 	FilePath(label, defaultPath string, shouldExist bool) string
 	Confirm(question string) bool
 }
@@ -81,6 +83,22 @@ func (_ prompter) InputNonEmpty(label, defaultString string) string {
 	res, _ := p.Run()
 
 	return res
+}
+
+func (pr prompter) InputMany(label string) []string {
+	endPromptInstruction := "(press return without entering anything to finish input)"
+	completeInputLabel := fmt.Sprintf("%s %s", label, endPromptInstruction)
+
+	var collection []string
+	for {
+		if in := pr.Input(completeInputLabel, ""); len(in) > 0 {
+			collection = append(collection, in)
+		} else {
+			break
+		}
+	}
+
+	return collection
 }
 
 func (_ prompter) FilePath(label, defaultPath string, shouldExist bool) string {


### PR DESCRIPTION
This PR resolves #78 

## Changes

- Adds CORS options support in Wizard for all flows whose generator supports CORS options

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
