### PR TITLE
ci: update Go to 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.17
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
This PR updates Go version in CI scripts to 1.17

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
