### PR TITLE
Ambassador - Provide possibility to disable everything at root level - with corresponding possibility to enable at path/method level 

### DIFF
--- a/generators/ambassador/ambassador_test.go
+++ b/generators/ambassador/ambassador_test.go
@@ -19,38 +19,25 @@ type testCase struct {
 }
 
 func TestAmbassador(t *testing.T) {
-	var gen Generator
+	trueValue := true
+	falseValue := false
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			r := require.New(t)
-
-			spec, err := spec.NewParser(openapi3.NewLoader()).ParseFromReader(strings.NewReader(testCase.spec))
-			r.NoError(err, "failed to parse spec")
-
-			mappings, err := gen.Generate(&testCase.options, spec)
-			r.NoError(err)
-			r.Equal(testCase.res, mappings)
-		})
-	}
-}
-
-var testCases = []testCase{
-	{
-		name: "basic",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
+	var testCases = []testCase{
+		{
+			name: "basic",
+			options: options.Options{
 				Namespace: "default",
-				Name:      "petstore",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
 			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
-		},
-		spec: `
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -67,7 +54,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -80,22 +67,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "basic-json",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "basic-json",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 {
   "openapi": "3.0.2",
   "info": {
@@ -116,7 +103,7 @@ spec:
   }
 }
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -129,22 +116,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "basic-namespace",
-		options: options.Options{
-			Namespace: "amb",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "basic-namespace",
+			options: options.Options{
+				Namespace: "amb",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -157,7 +144,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -170,22 +157,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "parameter",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "parameter",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -206,7 +193,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -220,22 +207,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "empty-operationId",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "empty-operationId",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -255,7 +242,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -269,22 +256,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "basepath",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "/api/v3",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "basepath",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "/api/v3",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -304,7 +291,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -318,22 +305,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "basepath-rootonly",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "/api/v3",
-				TrimPrefix: "",
-				Split:      false,
-			},
 		},
-		spec: `
+		{
+			name: "basepath-rootonly",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "/api/v3",
+					TrimPrefix: "",
+					Split:      false,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -359,7 +346,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -371,22 +358,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "basepath-trimprefix",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "/petstore/api/v3",
-				TrimPrefix: "/petstore",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "basepath-trimprefix",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "/petstore/api/v3",
+					TrimPrefix: "/petstore",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -406,7 +393,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -422,22 +409,22 @@ spec:
     pattern: '/petstore(.*)'
     substitution: '\1'
 `,
-	},
-	{
-		name: "swagger-yaml",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "swagger-yaml",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 swagger: "2.0"
 info:
   version: 1.0.0
@@ -520,7 +507,7 @@ definitions:
       message:
         type: string
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -556,22 +543,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "swagger-json",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "swagger-json",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 {
   "swagger": "2.0",
   "info": {
@@ -697,7 +684,7 @@ spec:
   }
 }
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -733,23 +720,23 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "port specified",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-				Port:      443,
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "port specified",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+					Port:      443,
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -762,7 +749,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -775,23 +762,23 @@ spec:
   service: petstore.default:443
   rewrite: ""
 `,
-	},
-	{
-		name: "port 0 specified",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-				Port:      0,
-			},
-			Path: options.PathOptions{
-				Base:       "",
-				TrimPrefix: "",
-				Split:      true,
-			},
 		},
-		spec: `
+		{
+			name: "port 0 specified",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+					Port:      0,
+				},
+				Path: options.PathOptions{
+					Base:       "",
+					TrimPrefix: "",
+					Split:      true,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -804,7 +791,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -817,22 +804,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "path-disabled",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
+		},
+		{
+			name: "path-disabled",
+			options: options.Options{
 				Namespace: "default",
-				Name:      "petstore",
-			},
-			PathSubOptions: map[string]options.SubOptions{
-				"/pet": {
-					Disabled: true,
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				PathSubOptions: map[string]options.SubOptions{
+					"/pet": {
+						Disabled: &trueValue,
+					},
 				},
 			},
-		},
-		spec: `
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -860,7 +847,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -874,22 +861,22 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "operation-disabled",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
+		},
+		{
+			name: "operation-disabled",
+			options: options.Options{
 				Namespace: "default",
-				Name:      "petstore",
-			},
-			OperationSubOptions: map[string]options.SubOptions{
-				"PUT/pet": {
-					Disabled: true,
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				OperationSubOptions: map[string]options.SubOptions{
+					"PUT/pet": {
+						Disabled: &trueValue,
+					},
 				},
 			},
-		},
-		spec: `
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -917,7 +904,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -931,25 +918,25 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "cors-global",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			CORS: options.CORSOptions{
-				Origins:       []string{"http://foo.example", "http://bar.example"},
-				Methods:       []string{"POST", "GET", "OPTIONS"},
-				Headers:       []string{"Content-Type"},
-				ExposeHeaders: []string{"X-Custom-Header", "X-Other-Custom-Header"},
-				Credentials:   nil,
-				MaxAge:        120,
-			},
 		},
-		spec: `
+		{
+			name: "cors-global",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				CORS: options.CORSOptions{
+					Origins:       []string{"http://foo.example", "http://bar.example"},
+					Methods:       []string{"POST", "GET", "OPTIONS"},
+					Headers:       []string{"Content-Type"},
+					ExposeHeaders: []string{"X-Custom-Header", "X-Other-Custom-Header"},
+					Credentials:   nil,
+					MaxAge:        120,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -975,7 +962,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -994,40 +981,40 @@ spec:
     credentials: false
     max_age: "120"
 `,
-	},
-	{
-		name: "cors-path-override",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
+		},
+		{
+			name: "cors-path-override",
+			options: options.Options{
 				Namespace: "default",
-				Name:      "petstore",
-			},
-			CORS: options.CORSOptions{
-				Origins:       []string{"http://foo.example", "http://bar.example"},
-				Methods:       []string{"POST", "GET", "OPTIONS"},
-				Headers:       []string{"Content-Type"},
-				ExposeHeaders: []string{"X-Custom-Header", "X-Other-Custom-Header"},
-				Credentials:   nil,
-				MaxAge:        120,
-			},
-			Timeouts: options.TimeoutOptions{
-				RequestTimeout: 5,
-			},
-			PathSubOptions: map[string]options.SubOptions{
-				"/pet": {
-					CORS: options.CORSOptions{
-						Origins:       []string{"http://bar.example"},
-						Methods:       []string{"POST"},
-						Headers:       []string{"Content-Type"},
-						ExposeHeaders: []string{"X-Custom-Header", "X-Other-Custom-Header"},
-						Credentials:   nil,
-						MaxAge:        240,
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				CORS: options.CORSOptions{
+					Origins:       []string{"http://foo.example", "http://bar.example"},
+					Methods:       []string{"POST", "GET", "OPTIONS"},
+					Headers:       []string{"Content-Type"},
+					ExposeHeaders: []string{"X-Custom-Header", "X-Other-Custom-Header"},
+					Credentials:   nil,
+					MaxAge:        120,
+				},
+				Timeouts: options.TimeoutOptions{
+					RequestTimeout: 5,
+				},
+				PathSubOptions: map[string]options.SubOptions{
+					"/pet": {
+						CORS: options.CORSOptions{
+							Origins:       []string{"http://bar.example"},
+							Methods:       []string{"POST"},
+							Headers:       []string{"Content-Type"},
+							ExposeHeaders: []string{"X-Custom-Header", "X-Other-Custom-Header"},
+							Credentials:   nil,
+							MaxAge:        240,
+						},
 					},
 				},
 			},
-		},
-		spec: `
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -1053,7 +1040,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -1094,21 +1081,21 @@ spec:
     max_age: "120"
   timeout_ms: 5000
 `,
-	},
-	{
-		name: "timeouts-global",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Timeouts: options.TimeoutOptions{
-				RequestTimeout: 42,
-				IdleTimeout:    43,
-			},
 		},
-		spec: `
+		{
+			name: "timeouts-global",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Timeouts: options.TimeoutOptions{
+					RequestTimeout: 42,
+					IdleTimeout:    43,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -1134,7 +1121,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -1148,29 +1135,29 @@ spec:
   timeout_ms: 42000
   idle_timeout_ms: 43000
 `,
-	},
-	{
-		name: "timeouts-path-override",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
+		},
+		{
+			name: "timeouts-path-override",
+			options: options.Options{
 				Namespace: "default",
-				Name:      "petstore",
-			},
-			Timeouts: options.TimeoutOptions{
-				RequestTimeout: 42,
-				IdleTimeout:    43,
-			},
-			PathSubOptions: map[string]options.SubOptions{
-				"/pet": {
-					Timeouts: options.TimeoutOptions{
-						RequestTimeout: 35,
-						IdleTimeout:    36,
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Timeouts: options.TimeoutOptions{
+					RequestTimeout: 42,
+					IdleTimeout:    43,
+				},
+				PathSubOptions: map[string]options.SubOptions{
+					"/pet": {
+						Timeouts: options.TimeoutOptions{
+							RequestTimeout: 35,
+							IdleTimeout:    36,
+						},
 					},
 				},
 			},
-		},
-		spec: `
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -1196,7 +1183,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -1225,18 +1212,18 @@ spec:
   timeout_ms: 42000
   idle_timeout_ms: 43000
 `,
-	},
-	{
-		name: "host path set",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			Host: "somehost.io",
 		},
-		spec: `
+		{
+			name: "host path set",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				Host: "somehost.io",
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -1254,7 +1241,7 @@ paths:
         '200':
           description: Successful operation
 `,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -1267,21 +1254,21 @@ spec:
   service: petstore.default:80
   rewrite: ""
 `,
-	},
-	{
-		name: "rate-limit-global",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
-				Namespace: "default",
-				Name:      "petstore",
-			},
-			RateLimits: options.RateLimitOptions{
-				RPS:   100,
-				Burst: 200,
-			},
 		},
-		spec: `
+		{
+			name: "rate-limit-global",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				RateLimits: options.RateLimitOptions{
+					RPS:   100,
+					Burst: 200,
+				},
+			},
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -1307,7 +1294,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -1342,29 +1329,29 @@ spec:
       burstFactor: 2
       unit: second
 `,
-	},
-	{
-		name: "rate-limit-path-override",
-		options: options.Options{
-			Namespace: "default",
-			Service: options.ServiceOptions{
+		},
+		{
+			name: "rate-limit-path-override",
+			options: options.Options{
 				Namespace: "default",
-				Name:      "petstore",
-			},
-			RateLimits: options.RateLimitOptions{
-				RPS:   40,
-				Burst: 80,
-			},
-			PathSubOptions: map[string]options.SubOptions{
-				"/pet": {
-					RateLimits: options.RateLimitOptions{
-						RPS:   20,
-						Burst: 40,
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				RateLimits: options.RateLimitOptions{
+					RPS:   40,
+					Burst: 80,
+				},
+				PathSubOptions: map[string]options.SubOptions{
+					"/pet": {
+						RateLimits: options.RateLimitOptions{
+							RPS:   20,
+							Burst: 40,
+						},
 					},
 				},
 			},
-		},
-		spec: `
+			spec: `
 openapi: 3.0.2
 info:
   title: Swagger Petstore - OpenAPI 3.0
@@ -1390,7 +1377,7 @@ paths:
       responses:
         '200':
           description: Successful operation`,
-		res: `
+			res: `
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
@@ -1461,5 +1448,208 @@ spec:
       burstFactor: 2
       unit: second
 `,
-	},
+		},
+		{
+			name: "globally disabled",
+			options: options.Options{
+				Disabled:  true,
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+			},
+			spec: `
+openapi: 3.0.2
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  version: 1.0.5
+x-kusk:
+  disabled: true
+paths:
+  /:
+    get: {}
+    post: {}
+`,
+			res: `
+`,
+		},
+		{
+			name: "path disabled, operation enabled",
+			options: options.Options{
+				Disabled:  true,
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				PathSubOptions: map[string]options.SubOptions{
+					"/": {
+						Disabled: &trueValue,
+					},
+				},
+				OperationSubOptions: map[string]options.SubOptions{
+					"GET/": {
+						Disabled: &falseValue,
+					},
+				},
+			},
+			spec: `
+openapi: 3.0.2
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  version: 1.0.5
+paths:
+  /:
+    x-kusk:
+      disabled: true
+    get:
+      x-kusk:
+        disabled: false
+    post: {}
+`,
+			res: `
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: petstore-get
+  namespace: default
+spec:
+  prefix: "/"
+  method: GET
+  service: petstore.default:80
+  rewrite: ""
+`,
+		},
+		{
+			name: "path disabled not specified operation disabled specified",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				OperationSubOptions: map[string]options.SubOptions{
+					"GET/": {
+						Disabled: &trueValue,
+					},
+					"POST/": {
+						Disabled: &falseValue,
+					},
+					"PATCH/": {
+						Disabled: &falseValue,
+					},
+				},
+			},
+			spec: `
+openapi: 3.0.2
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  version: 1.0.5
+paths:
+  /:
+    get:
+      x-kusk:
+        disabled: true
+    post:
+      x-kusk:
+        disabled: false
+    patch:
+      x-kusk:
+        disabled: false
+`,
+			res: `
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: petstore-patch
+  namespace: default
+spec:
+  prefix: "/"
+  method: PATCH
+  service: petstore.default:80
+  rewrite: ""
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: petstore-post
+  namespace: default
+spec:
+  prefix: "/"
+  method: POST
+  service: petstore.default:80
+  rewrite: ""
+`,
+		},
+		{
+			name: "path disabled not specified operation disabled specified operation enabled not specified",
+			options: options.Options{
+				Namespace: "default",
+				Service: options.ServiceOptions{
+					Namespace: "default",
+					Name:      "petstore",
+				},
+				OperationSubOptions: map[string]options.SubOptions{
+					"GET/": {
+						Disabled: &trueValue,
+					},
+				},
+			},
+			spec: `
+openapi: 3.0.2
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  version: 1.0.5
+paths:
+  /:
+    get:
+      x-kusk:
+        disabled: true
+    post: {}
+    patch: {}
+`,
+			res: `
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: petstore-patch
+  namespace: default
+spec:
+  prefix: "/"
+  method: PATCH
+  service: petstore.default:80
+  rewrite: ""
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: petstore-post
+  namespace: default
+spec:
+  prefix: "/"
+  method: POST
+  service: petstore.default:80
+  rewrite: ""
+`,
+		},
+	}
+
+	var gen Generator
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			r := require.New(t)
+
+			spec, err := spec.NewParser(openapi3.NewLoader()).ParseFromReader(strings.NewReader(testCase.spec))
+			r.NoError(err, "failed to parse spec")
+
+			mappings, err := gen.Generate(&testCase.options, spec)
+			r.NoError(err)
+			r.Equal(testCase.res, mappings)
+		})
+	}
 }

--- a/generators/linkerd/linkerd.go
+++ b/generators/linkerd/linkerd.go
@@ -91,12 +91,12 @@ func (g *Generator) generateServiceProfileSpec(options *options.Options, spec *o
 	routes := make([]*v1alpha2.RouteSpec, 0)
 
 	for path, pathItem := range spec.Paths {
-		if pathDisabled(path, options) {
+		if options.IsPathDisabled(path) {
 			continue
 		}
 
 		for method, _ := range pathItem.Operations() {
-			if operationDisabled(method+path, options) {
+			if options.IsOperationDisabled(path, method) {
 				continue
 			}
 
@@ -109,16 +109,6 @@ func (g *Generator) generateServiceProfileSpec(options *options.Options, spec *o
 	})
 
 	return v1alpha2.ServiceProfileSpec{Routes: routes}
-}
-
-func pathDisabled(path string, options *options.Options) bool {
-	pathOpts, ok := options.PathSubOptions[path]
-	return ok && pathOpts.Disabled
-}
-
-func operationDisabled(operation string, options *options.Options) bool {
-	operationOpts, ok := options.OperationSubOptions[operation]
-	return ok && operationOpts.Disabled
 }
 
 func generateRouteSpec(method, path string, opts *options.Options) *v1alpha2.RouteSpec {

--- a/generators/linkerd/linkerd_test.go
+++ b/generators/linkerd/linkerd_test.go
@@ -35,6 +35,8 @@ func TestLinkerd(t *testing.T) {
 	}
 }
 
+var trueValue = true
+
 var testCases = []testCase{
 	{
 		name: "simple routes",
@@ -197,7 +199,7 @@ spec:
 			},
 			PathSubOptions: map[string]options.SubOptions{
 				"/books": {
-					Disabled: true,
+					Disabled: &trueValue,
 				},
 			},
 		},
@@ -266,7 +268,7 @@ spec:
 			},
 			OperationSubOptions: map[string]options.SubOptions{
 				"GET/books": {
-					Disabled: true,
+					Disabled: &trueValue,
 				},
 			},
 		},

--- a/generators/nginx_ingress/nginx_ingress.go
+++ b/generators/nginx_ingress/nginx_ingress.go
@@ -113,10 +113,8 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 
 	if g.shouldSplit(opts, spec) {
 		for path := range spec.Paths {
-			if pathSubOptions, ok := opts.PathSubOptions[path]; ok {
-				if pathSubOptions.Disabled {
-					continue
-				}
+			if opts.IsPathDisabled(path) {
+				continue
 			}
 
 			name := fmt.Sprintf("%s-%s", opts.Service.Name, ingressResourceNameFromPath(path))
@@ -334,7 +332,7 @@ func (g *Generator) shouldSplit(opts *options.Options, spec *openapi3.T) bool {
 	for path, pathItem := range spec.Paths {
 		if pathSubOptions, ok := opts.PathSubOptions[path]; ok {
 			// a path is disabled
-			if pathSubOptions.Disabled {
+			if opts.IsPathDisabled(path) {
 				return true
 			}
 

--- a/generators/traefik/traefik.go
+++ b/generators/traefik/traefik.go
@@ -10,13 +10,14 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/spf13/pflag"
 
-	yaml "github.com/ghodss/yaml"
-	"github.com/kubeshop/kusk/generators"
-	"github.com/kubeshop/kusk/options"
+	"github.com/ghodss/yaml"
 	traefikDynamicConfig "github.com/traefik/traefik/v2/pkg/config/dynamic"
 	traefikCRD "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/traefik/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kubeshop/kusk/generators"
+	"github.com/kubeshop/kusk/options"
 )
 
 const (
@@ -150,7 +151,7 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 		// x-kusk options per path
 		pathSubOpts, ok := opts.PathSubOptions[path]
 		if ok {
-			if pathSubOpts.Disabled {
+			if opts.IsPathDisabled(path) {
 				continue
 			}
 
@@ -186,7 +187,7 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 			opSubOpts, ok := opts.OperationSubOptions[method+path]
 			opServiceServersTransport := pathServiceServersTransport
 			if ok {
-				if opSubOpts.Disabled {
+				if opts.IsOperationDisabled(path, method) {
 					continue
 				}
 				if opSubOpts.Host != "" && opSubOpts.Host != host {

--- a/spec/extension_test.go
+++ b/spec/extension_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGetOptions(t *testing.T) {
+	trueValue := true
+
 	var testCases = []struct {
 		name string
 		spec *openapi3.T
@@ -37,7 +39,7 @@ func TestGetOptions(t *testing.T) {
 			res: options.Options{
 				PathSubOptions: map[string]options.SubOptions{
 					"/pet": {
-						Disabled: true,
+						Disabled: &trueValue,
 					},
 				},
 			},
@@ -60,7 +62,7 @@ func TestGetOptions(t *testing.T) {
 			res: options.Options{
 				OperationSubOptions: map[string]options.SubOptions{
 					"PUT/pet": {
-						Disabled: true,
+						Disabled: &trueValue,
 					},
 				},
 			},


### PR DESCRIPTION
Add global level disable option to enable blanket disable on all paths
and operations. Paths and Operations can then be enabled when they are
deemed to be ready by overriding the disabled field at the path and
field levels.

Change disabled field in SubOptions from boolean to pointer to a boolean
to implement the following semantics:
- If nil, not explicitely set, then check for value at level above -
 if at operation, check path level. If at path level, check global
level
- If has a value be it True or False, disregard the disabled setting at
  the level above as it has been explicitely set

Implement useful helper methods IsOperationDisabled and IsPathDisabled
with the Option struct reciever which implement the semantics listed
above

resolves #148 

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
