### PR TITLE
Nginx-Ingress - Provide possibility to disable everything at root level - with corresponding possibility to enable at path level 

### DIFF
--- a/generators/ambassador/ambassador.go
+++ b/generators/ambassador/ambassador.go
@@ -416,13 +416,12 @@ func (g *Generator) shouldSplit(opts *options.Options, spec *openapi3.T) bool {
 	}
 
 	for path, pathItem := range spec.Paths {
+		// a path is disabled
+		if opts.IsPathDisabled(path) {
+			return true
+		}
 
 		if pathSubOptions, ok := opts.PathSubOptions[path]; ok {
-			// a path is disabled
-			if opts.IsPathDisabled(path) {
-				return true
-			}
-
 			// a path has non-zero, different from global scope CORS options
 			if !reflect.DeepEqual(options.CORSOptions{}, pathSubOptions.CORS) &&
 				!reflect.DeepEqual(opts.CORS, pathSubOptions.CORS) {

--- a/generators/ambassador/ambassador.go
+++ b/generators/ambassador/ambassador.go
@@ -416,11 +416,17 @@ func (g *Generator) shouldSplit(opts *options.Options, spec *openapi3.T) bool {
 	}
 
 	for path, pathItem := range spec.Paths {
-		// a path is disabled
+		for method := range pathItem.Operations() {
+			if opts.IsOperationDisabled(path, method) {
+				return true
+			}
+		}
 		if opts.IsPathDisabled(path) {
 			return true
 		}
+	}
 
+	for path, pathItem := range spec.Paths {
 		if pathSubOptions, ok := opts.PathSubOptions[path]; ok {
 			// a path has non-zero, different from global scope CORS options
 			if !reflect.DeepEqual(options.CORSOptions{}, pathSubOptions.CORS) &&
@@ -443,11 +449,6 @@ func (g *Generator) shouldSplit(opts *options.Options, spec *openapi3.T) bool {
 
 		for method := range pathItem.Operations() {
 			if opSubOptions, ok := opts.OperationSubOptions[method+path]; ok {
-				// an operation is disabled
-				if opts.IsOperationDisabled(path, method) {
-					return true
-				}
-
 				// an operation has non-zero, different from global CORS options
 				if !reflect.DeepEqual(options.CORSOptions{}, opSubOptions.CORS) &&
 					!reflect.DeepEqual(opts.CORS, opSubOptions.CORS) {

--- a/generators/ambassador/ambassador_test.go
+++ b/generators/ambassador/ambassador_test.go
@@ -1477,7 +1477,6 @@ paths:
 		{
 			name: "path disabled, operation enabled",
 			options: options.Options{
-				Disabled:  true,
 				Namespace: "default",
 				Service: options.ServiceOptions{
 					Namespace: "default",

--- a/generators/nginx_ingress/nginx_ingress.go
+++ b/generators/nginx_ingress/nginx_ingress.go
@@ -196,7 +196,7 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 
 			ingresses = append(ingresses, ingress)
 		}
-	} else {
+	} else if !opts.Disabled {
 		ingress := g.newIngressResource(
 			fmt.Sprintf("%s-ingress", opts.Service.Name),
 			opts.Namespace,
@@ -330,12 +330,12 @@ func (g *Generator) shouldSplit(opts *options.Options, spec *openapi3.T) bool {
 	warnGroupUnsupported(opts.RateLimits)
 
 	for path, pathItem := range spec.Paths {
-		if pathSubOptions, ok := opts.PathSubOptions[path]; ok {
-			// a path is disabled
-			if opts.IsPathDisabled(path) {
-				return true
-			}
+		// a path is disabled
+		if opts.IsPathDisabled(path) {
+			return true
+		}
 
+		if pathSubOptions, ok := opts.PathSubOptions[path]; ok {
 			// a path has non-zero, different from global scope CORS options
 			if !reflect.DeepEqual(options.CORSOptions{}, pathSubOptions.CORS) &&
 				!reflect.DeepEqual(opts.CORS, pathSubOptions.CORS) {


### PR DESCRIPTION
## Changes
### Ambassador
Move path disabled checkout outside of the sub options look up. If a
path has no kusk settings and thus enabled by default, kusk would skip
it and not include it in the generated resources. This commit fixes this

### Nginx-Ingress
Support disabled option resolution using the semantics where lower level
disabled settings (Path > Global) take precendence. This is not
implemented for operations as the nginx-ingress generator doesn't
support operation level settings

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
