### PR TITLE
Ambassador2 removed AmbassadorMapping in exchange for Mapping as of V…

### DIFF
--- a/docs/ambassador2.md
+++ b/docs/ambassador2.md
@@ -26,7 +26,7 @@ Flags:
   -h, --help
 ```
 
-The Ambassador generator generates [AmbassadorMapping]s (https://www.getambassador.io/docs/edge-stack/2.0/topics/using/intro-mappings/) resources for mapping resource to services. All options that can be set via 
+The Ambassador generator generates [Mapping]s (https://www.getambassador.io/docs/edge-stack/2.0/topics/using/intro-mappings/) resources for mapping resource to services. All options that can be set via 
 flags can also be set using our `x-kusk` OpenAPI extension in your specification.
 
 CLI flags apply only at the global level i.e. applies to all paths and methods.
@@ -44,7 +44,7 @@ To override settings on the path or HTTP method level, you are required to use t
 | Path Base               | --path.base                | path.base                 | Prefix for your resource routes                                                                                    | ❌                             |
 | Path Trim Prefix        | --path.trim_prefix         | path.trim_prefix          | Trim the specified prefix from URl before passing request onto service                                             | ❌                             |
 | Path split              | --path.split               | path.split                | Boolean; whether or not to force generator to generate a mapping for each path                                     | ❌                             |
-| Host                    | --host                     | host                      | The value to set the host field to in the AmbassadorMapping resource                                                         | ✅                             |
+| Host                    | --host                     | host                      | The value to set the host field to in the Mapping resource                                                         | ✅                             |
 | Rate limit (RPS)        | --rate_limits.rps          | rate_limits.rps           | Request per second rate limit                                                                                      | ✅                             |
 | Rate limit (burst)      | --rate_limits.burst        | rate_limits.burst         | Rate limit burst                                                                                                   | ✅                             |
 | Rate limit group        | N/A                        | rate_limits.group         | Rate limit endpoint group                                                                                          |                               |
@@ -167,7 +167,7 @@ paths:
 ```yaml
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: booksapp
   namespace: booksapp
@@ -228,7 +228,7 @@ paths:
 ```yaml
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: booksapp-get
   namespace: booksapp
@@ -240,7 +240,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: booksapp-postbooks
   namespace: booksapp
@@ -304,7 +304,7 @@ paths:
 ```yaml
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: booksapp
   namespace: booksapp
@@ -368,7 +368,7 @@ paths:
 ```yaml
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: booksapp
   namespace: booksapp
@@ -426,7 +426,7 @@ paths:
 ```yaml
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: webapp
   namespace: booksapp
@@ -505,7 +505,7 @@ paths:
 ```yaml
 ----
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: webapp-get
   namespace: booksapp
@@ -528,7 +528,7 @@ spec:
     max_age: "86400"
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: webapp-postbooks
   namespace: booksapp

--- a/generators/ambassador/v2/ambassador_test.go
+++ b/generators/ambassador/v2/ambassador_test.go
@@ -59,7 +59,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -110,7 +110,7 @@ spec:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -153,7 +153,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -204,7 +204,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -255,7 +255,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-postpetpetiduploadimage
@@ -306,7 +306,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-postpetpetiduploadimage
@@ -363,7 +363,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore
@@ -412,7 +412,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-postpetpetiduploadimage
@@ -528,7 +528,7 @@ definitions:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-createpets
@@ -540,7 +540,7 @@ spec:
   service: petstore.default:80
   rewrite: ""
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-listpets
@@ -552,7 +552,7 @@ spec:
   service: petstore.default:80
   rewrite: ""
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-showpetbyid
@@ -709,7 +709,7 @@ spec:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-createpets
@@ -721,7 +721,7 @@ spec:
   service: petstore.default:80
   rewrite: ""
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-listpets
@@ -733,7 +733,7 @@ spec:
   service: petstore.default:80
   rewrite: ""
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-showpetbyid
@@ -778,7 +778,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -822,7 +822,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -880,7 +880,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -939,7 +939,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -999,7 +999,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore
@@ -1087,7 +1087,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -1112,7 +1112,7 @@ spec:
     max_age: "240"
   timeout_ms: 5000
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -1184,7 +1184,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore
@@ -1248,7 +1248,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -1262,7 +1262,7 @@ spec:
   timeout_ms: 35000
   idle_timeout_ms: 36000
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -1308,7 +1308,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore
@@ -1362,7 +1362,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore
@@ -1444,7 +1444,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -1462,7 +1462,7 @@ spec:
       - request:
           - remote-address
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -1562,7 +1562,7 @@ paths:
           description: Successful operation`,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-updatepet
@@ -1580,7 +1580,7 @@ spec:
       - request:
           - remote-address
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-uploadfile
@@ -1676,7 +1676,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-get
@@ -1729,7 +1729,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-patch
@@ -1741,7 +1741,7 @@ spec:
   service: petstore.default:80
   rewrite: ""
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-post
@@ -1784,7 +1784,7 @@ paths:
 `,
 			res: `
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-patch
@@ -1796,7 +1796,7 @@ spec:
   service: petstore.default:80
   rewrite: ""
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: petstore-post

--- a/generators/ambassador/v2/ambassador_test.go
+++ b/generators/ambassador/v2/ambassador_test.go
@@ -60,7 +60,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -111,7 +111,7 @@ spec:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -154,7 +154,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: amb
@@ -205,7 +205,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -256,7 +256,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-postpetpetiduploadimage
   namespace: default
@@ -307,7 +307,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-postpetpetiduploadimage
   namespace: default
@@ -364,7 +364,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore
   namespace: default
@@ -413,7 +413,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-postpetpetiduploadimage
   namespace: default
@@ -529,7 +529,7 @@ definitions:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-createpets
   namespace: default
@@ -541,7 +541,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-listpets
   namespace: default
@@ -553,7 +553,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-showpetbyid
   namespace: default
@@ -710,7 +710,7 @@ spec:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-createpets
   namespace: default
@@ -722,7 +722,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-listpets
   namespace: default
@@ -734,7 +734,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-showpetbyid
   namespace: default
@@ -779,7 +779,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -823,7 +823,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -881,7 +881,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -940,7 +940,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -1000,7 +1000,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore
   namespace: default
@@ -1088,7 +1088,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -1113,7 +1113,7 @@ spec:
   timeout_ms: 5000
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -1185,7 +1185,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore
   namespace: default
@@ -1249,7 +1249,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -1263,7 +1263,7 @@ spec:
   idle_timeout_ms: 36000
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -1309,7 +1309,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore
   namespace: default
@@ -1363,7 +1363,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore
   namespace: default
@@ -1445,7 +1445,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -1463,7 +1463,7 @@ spec:
           - remote-address
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -1563,7 +1563,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-updatepet
   namespace: default
@@ -1581,7 +1581,7 @@ spec:
           - remote-address
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-uploadfile
   namespace: default
@@ -1677,7 +1677,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-get
   namespace: default
@@ -1730,7 +1730,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-patch
   namespace: default
@@ -1742,7 +1742,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-post
   namespace: default
@@ -1785,7 +1785,7 @@ paths:
 			res: `
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-patch
   namespace: default
@@ -1797,7 +1797,7 @@ spec:
   rewrite: ""
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: petstore-post
   namespace: default
@@ -1825,9 +1825,9 @@ spec:
 			spec, err := spec.NewParser(openapi3.NewLoader()).ParseFromReader(strings.NewReader(testCase.spec))
 			r.NoError(err, "failed to parse spec")
 
-			AmbassadorMappings, err := gen.Generate(&testCase.options, spec)
+			Mappings, err := gen.Generate(&testCase.options, spec)
 			r.NoError(err)
-			r.Equal(testCase.res, AmbassadorMappings)
+			r.Equal(testCase.res, Mappings)
 		})
 	}
 }

--- a/generators/ambassador/v2/mapping_template.go
+++ b/generators/ambassador/v2/mapping_template.go
@@ -2,7 +2,7 @@ package v2
 
 var mappingTemplateRaw = `{{range .}}
 ---
-apiVersion: x.getambassador.io/v3alpha1
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 metadata:
   name: {{.MappingName}}

--- a/generators/ambassador/v2/mapping_template.go
+++ b/generators/ambassador/v2/mapping_template.go
@@ -3,7 +3,7 @@ package v2
 var mappingTemplateRaw = `{{range .}}
 ---
 apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+kind: Mapping
 metadata:
   name: {{.MappingName}}
   namespace: {{.MappingNamespace}}


### PR DESCRIPTION
…ersion 2.0.4

This PR...

## Changes
 In Ambassador Version Version 2.0.4 (October 19, 2021), the prefix "Ambassador" was removed. 
[Updates](https://www.getambassador.io/docs/edge-stack/latest/release-notes/#gatsby-focus-wrapper)
-

## Fixes
Removed the prefix "Ambassador" from Mapping Kind
-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
