### PR TITLE
Docs and fix: path rewrite flag

### DIFF
--- a/generators/ambassador/ambassador.go
+++ b/generators/ambassador/ambassador.go
@@ -122,8 +122,8 @@ func (a *AbstractGenerator) Generate(opts *options.Options, spec *openapi3.T) (s
 				mappingName := generateMappingName(opts.Service.Name, method, path, operation)
 
 				var pathRewrite string
-				if opts.Path.RewriteBase != "" {
-					pathRewrite = strings.TrimSuffix(opts.Path.RewriteBase, "/") + mappingPath
+				if opts.Path.Rewrite != "" {
+					pathRewrite = strings.TrimSuffix(opts.Path.Rewrite, "/") + mappingPath
 				}
 
 				op := mappingTemplateData{
@@ -220,7 +220,7 @@ func (a *AbstractGenerator) Generate(opts *options.Options, spec *openapi3.T) (s
 			ServiceURL:       serviceURL,
 			BasePath:         opts.Path.Base,
 			TrimPrefix:       opts.Path.TrimPrefix,
-			PathRewrite:      strings.TrimSuffix(opts.Path.RewriteBase, "/"),
+			PathRewrite:      opts.Path.Rewrite,
 			RequestTimeout:   opts.Timeouts.RequestTimeout * 1000,
 			IdleTimeout:      opts.Timeouts.IdleTimeout * 1000,
 			Host:             opts.Host,

--- a/generators/ambassador/v1/ambassador_test.go
+++ b/generators/ambassador/v1/ambassador_test.go
@@ -1756,7 +1756,7 @@ paths:
 				Host:      "*",
 				Path: options.PathOptions{
 					Base:        "/my-bookstore",
-					RewriteBase: "/bookstore/",
+					Rewrite: "/bookstore/",
 				},
 				Service: options.ServiceOptions{
 					Namespace: "booksapp",
@@ -1775,7 +1775,7 @@ spec:
   prefix: "/my-bookstore"
   host: *
   service: webapp.booksapp:7000
-  rewrite: "/bookstore"
+  rewrite: "/bookstore/"
 `,
 		},
 		{
@@ -1819,7 +1819,7 @@ paths:
 				Host:      "*",
 				Path: options.PathOptions{
 					Base:        "/my-bookstore/",
-					RewriteBase: "/bookstore/",
+					Rewrite: "/bookstore/",
 				},
 				Service: options.ServiceOptions{
 					Namespace: "booksapp",

--- a/generators/ambassador/v2/ambassador_test.go
+++ b/generators/ambassador/v2/ambassador_test.go
@@ -1838,7 +1838,7 @@ paths:
 				Host:      "*",
 				Path: options.PathOptions{
 					Base:        "/my-bookstore",
-					RewriteBase: "/bookstore/",
+					Rewrite: "/bookstore/",
 				},
 				Service: options.ServiceOptions{
 					Namespace: "booksapp",
@@ -1857,7 +1857,7 @@ spec:
   prefix: "/my-bookstore"
   hostname: '*'
   service: webapp.booksapp:7000
-  rewrite: "/bookstore"
+  rewrite: "/bookstore/"
 `,
 		},
 		{
@@ -1901,7 +1901,7 @@ paths:
 				Host:      "*",
 				Path: options.PathOptions{
 					Base:        "/my-bookstore/",
-					RewriteBase: "/bookstore/",
+					Rewrite: "/bookstore/",
 				},
 				Service: options.ServiceOptions{
 					Namespace: "booksapp",

--- a/options/path.go
+++ b/options/path.go
@@ -1,7 +1,7 @@
 package options
 
 import (
-	"github.com/go-ozzo/ozzo-validation/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 type PathOptions struct {
@@ -15,9 +15,9 @@ type PathOptions struct {
 	// is "/api/v3/pets".
 	TrimPrefix string `yaml:"trim_prefix,omitempty" json:"trim_prefix,omitempty"`
 
-	// RewriteBase is the rewrite value that should replace the Base path before being forwarded to the
+	// Rewrite is the rewrite value that should replace the Base path before being forwarded to the
 	// upstream service
-	RewriteBase string `yaml:"rewrite_base,omitempty" json:"rewrite_base,omitempty"`
+	Rewrite string `yaml:"rewrite,omitempty" json:"rewrite_base,omitempty"`
 
 	// Split forces Kusk to generate a separate resource for each Path or Operation, where appropriate.
 	Split bool `yaml:"split,omitempty" json:"split,omitempty"`

--- a/options/path.go
+++ b/options/path.go
@@ -17,7 +17,7 @@ type PathOptions struct {
 
 	// Rewrite is the rewrite value that should replace the Base path before being forwarded to the
 	// upstream service
-	Rewrite string `yaml:"rewrite,omitempty" json:"rewrite_base,omitempty"`
+	Rewrite string `yaml:"rewrite,omitempty" json:"rewrite,omitempty"`
 
 	// Split forces Kusk to generate a separate resource for each Path or Operation, where appropriate.
 	Split bool `yaml:"split,omitempty" json:"split,omitempty"`


### PR DESCRIPTION
This PR adds docs with instructions and an example on how to use the rewrite option and removes the stripping of the trailing `/` when the paths aren't being split into separate resources

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test
