### PR TITLE
Lowercased k8s name bug for ingress-nginx, documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Read the [Introductory blog-post](https://medium.com/kubeshop-i/hello-kusk-opena
 ### Latest release on Github
 `go install github.com/kubeshop/kusk@$VERSION`
 
+If you don't want to build it yourself, the [Releases](https://github.com/kubeshop/kusk/releases) page contains already built binaries for all supported platforms.
+
+Download it and unpack *kusk* to the directory of you choice.
+
 ### From source
 ```shell
 git clone git@github.com:kubeshop/kusk.git && \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,10 @@
 ### Latest release on Github
 `go install github.com/kubeshop/kusk@$VERSION`
 
+If you don't want to build it yourself, the [Releases](https://github.com/kubeshop/kusk/releases) page contains already built binaries for all supported platforms.
+
+Download it and unpack *kusk* to the directory of you choice.
+
 ### From source
 ```shell
 git clone git@github.com:kubeshop/kusk.git && \

--- a/generators/nginx_ingress/nginx_ingress.go
+++ b/generators/nginx_ingress/nginx_ingress.go
@@ -226,7 +226,7 @@ func ingressResourceNameFromPath(path string) string {
 	}
 
 	// remove trailing - character
-	return strings.TrimSuffix(b.String(), "-")
+	return strings.ToLower(strings.TrimSuffix(b.String(), "-"))
 }
 
 func (g *Generator) newIngressResource(


### PR DESCRIPTION


This PR...

## Changes

Make sure k8s resource names are correctly lowercased.

Extends the documentation with Releases page.

## Fixes

Fixes #199

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
