### PR TITLE
Rewrite annotation value now correct when base path is set and trim prefix isnt

### DIFF
--- a/generators/nginx_ingress/nginx_ingress.go
+++ b/generators/nginx_ingress/nginx_ingress.go
@@ -140,16 +140,22 @@ func (g *Generator) Generate(opts *options.Options, spec *openapi3.T) (string, e
 				pathField = opts.Path.Base + string(openApiPathVariableRegex.ReplaceAll([]byte(path), []byte("([A-z0-9]+)")))
 
 				// get the first capture group of regex. Given a path /books/{id}, will return /books/
-				rewrite := string(openApiPathVariableRegex.ReplaceAllLiteral([]byte(path), []byte("$1")))
+				rewrite := opts.Path.Base + string(openApiPathVariableRegex.ReplaceAllLiteral([]byte(path), []byte("$1")))
 				annotations[rewriteTargetAnnotationKey] = rewrite
 				annotations[useRegexAnnotationKey] = "true"
 			} else if path == "/" {
 				pathField = opts.Path.Base + "$"
-				annotations[rewriteTargetAnnotationKey] = "/"
+				annotations[rewriteTargetAnnotationKey] = opts.Path.Base + "/"
 				annotations[useRegexAnnotationKey] = "true"
 			} else {
 				pathField = opts.Path.Base + path
-				annotations[rewriteTargetAnnotationKey] = path
+				annotations[rewriteTargetAnnotationKey] = strings.TrimPrefix(pathField, opts.Path.TrimPrefix)
+			}
+
+			if rewriteValue, ok := annotations[rewriteTargetAnnotationKey]; ok {
+				rewriteValue = strings.ReplaceAll(rewriteValue, "//", "/")
+				rewriteValue = strings.TrimPrefix(rewriteValue, opts.Path.TrimPrefix)
+				annotations[rewriteTargetAnnotationKey] = rewriteValue
 			}
 
 			// Replace // with /


### PR DESCRIPTION
This PR fixed #202 

## Changes

- When setting rewrite annotation - append base path and then trim prefix only if trim prefix is set

## Fixes

- issue where base path wasnt included in rewrite annotation when base path is set and trim prefix isnt

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
