### PR TITLE
add envoyfleet name and namespace flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,76 @@ Currently we support the following commands:
 ```
 
 ## Api generate
+Generate accepts your OpenAPI spec file as input either as a local file or a URL pointing to your file
+and generates a Kusk Gateway compatible API resource that you can apply directly into your cluster.
+
+Configuration of the API resource is done via the x-kusk extension.
+
+If the OpenAPI spec doesn't have a top-level x-kusk annotation set, it will add them for you and set
+the upstream service, namespace and port to the flag values passed in respectively and set the rest of the settings to defaults.
+This is enough to get you started
+
+If the x-kusk extension is already present, it will override the the upstream service, namespace and port to the flag values passed in respectively
+and leave the rest of the settings as they are.
+
+You must specify the name of the envoyfleet you wish to use to expose your API. This is because Kusk Gateway could be managing more than one.
+In the future, we will add the notion of a default envoyfleet which kusk gateway will use when none is specified.
+
+If you do not specify the envoyfleet namespace, it will default to kusk-system.
+
+Sample usage
+
+No name specified
+
+```
+kusk api generate \
+  -i spec.yaml \
+  --envoyfleet.name kusk-gateway-envoy-fleet \
+  --envoyfleet.namespace kusk-system
+```
+
+In the above example, kusk will use the openapi spec info.title to generate a manifest name and leave the existing
+x-kusk extension settings
+
+No api namespace specified
+
+```
+kusk api generate \
+  -i spec.yaml \
+  --name httpbin-api \
+  --upstream.service httpbin \
+  --upstream.port 8080 \
+  --envoyfleet.name kusk-gateway-envoy-fleet
+```
+
+In the above example, as --namespace isn't defined, it will assume the default namespace.
+
+Namespace specified
+
+```
+kusk api generate \
+  -i spec.yaml \
+  --name httpbin-api \
+  --upstream.service httpbin \
+  --upstream.namespace my-namespace \
+  --upstream.port 8080 \
+  --envoyfleet.name kusk-gateway-envoy-fleet
+```
+
+OpenAPI spec at URL
+
+```
+kusk api generate \
+    -i https://raw.githubusercontent.com/$ORG_OR_USER/$REPO/myspec.yaml \
+    --name httpbin-api \
+    --upstream.service httpbin \
+    --upstream.namespace my-namespace \
+    --upstream.port 8080 \
+    --envoyfleet.name kusk-gateway-envoy-fleet
+```
+
+This will fetch the OpenAPI document from the provided URL and generate a Kusk Gateway API resource
+
 ### Flags
 |          Flag          |                                             Description                                             | Required? |
 |:----------------------:|:---------------------------------------------------------------------------------------------------:|:---------:|
@@ -62,12 +132,14 @@ Currently we support the following commands:
 |  `--upstream.service`  |                                 name of upstream Kubernetes service                                 |     ❌     |
 | `--upstream.namespace` |                           namespace of upstream service (default: default)                          |     ❌     |
 |    `--upstream.port`   |                        port that upstream service is exposed on (default: 80)                       |     ❌     |
+|   `--envoyfleet.name`  |                                name of envoyfleet to use for this API                               |     ✅     |
+| `envoyfleet.namespace` |                  namespace of envoyfleet to use for this API. Default: kusk-system                  |     ❌     |
 
 ### Example
 Take a look at the [http-bin example spec](./examples/httpbin-spec.yaml)
 
 ```
-kusk api generate -i ./examples/httpbin-spec.yaml --name httpbin-api --upstream.service httpbin --upstream.port 8080
+kusk api generate -i ./examples/httpbin-spec.yaml --name httpbin-api --upstream.service httpbin --upstream.port 8080 --envoyfleet.name kusk-gateway-envoy-fleet
 ```
 
 The output should contain the following x-kusk extension at the top level

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If the x-kusk extension is already present, it will override the the upstream se
 and leave the rest of the settings as they are.
 
 You must specify the name of the envoyfleet you wish to use to expose your API. This is because Kusk Gateway could be managing more than one.
-In the future, we will add the notion of a default envoyfleet which kusk gateway will use when none is specified.
+In the future, we will add the notion of a default envoyfleet which kusk gateway will use when none is specified. i.e. kusk-gateway-envoy-fleet.
 
 If you do not specify the envoyfleet namespace, it will default to kusk-system.
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -50,6 +50,9 @@ var (
 	serviceName      string
 	serviceNamespace string
 	servicePort      uint32
+
+	envoyFleetName      string
+	envoyFleetNamespace string
 )
 
 // generateCmd represents the generate command
@@ -67,23 +70,42 @@ var generateCmd = &cobra.Command{
 	This is enough to get you started
 
 	If the x-kusk extension is already present, it will override the the upstream service, namespace and port to the flag values passed in respectively
-	and leave the rest of the settings as they are
+	and leave the rest of the settings as they are.
+
+	You must specify the name of the envoyfleet you wish to use to expose your API. This is because Kusk Gateway could be managing more than one.
+	In the future, we will add the notion of a default envoyfleet which kusk gateway will use when none is specified.
+
+	If you do not specify the envoyfleet namespace, it will default to kusk-system.
 
 	Sample usage
 
 	No name specified
-	kusk api generate -i spec.yaml
+	kusk api generate \
+		-i spec.yaml \
+		--envoyfleet.name kusk-gateway-envoy-fleet \
+		--envoyfleet.namespace kusk-system
 
 	In the above example, kusk will use the openapi spec info.title to generate a manifest name and leave the existing
 	x-kusk extension settings
 	
-	No namespace specified
-	kusk api generate -i spec.yaml --name httpbin-api --upstream.service httpbin --upstream.port 8080
+	No api namespace specified
+	kusk api generate \
+		-i spec.yaml \
+		--name httpbin-api \
+		--upstream.service httpbin \
+		--upstream.port 8080 \
+		--envoyfleet.name kusk-gateway-envoy-fleet
 
 	In the above example, as --namespace isn't defined, it will assume the default namespace.
 
 	Namespace specified
-	kusk api generate -i spec.yaml --name httpbin-api --upstream.service httpbin --upstream.namespace my-namespace --upstream.port 8080
+	kusk api generate \
+		-i spec.yaml \
+		--name httpbin-api \
+		--upstream.service httpbin \
+		--upstream.namespace my-namespace \
+		--upstream.port 8080 \
+		--envoyfleet.name kusk-gateway-envoy-fleet
 
 	OpenAPI spec at URL
 	kusk api generate \
@@ -91,7 +113,8 @@ var generateCmd = &cobra.Command{
 			 --name httpbin-api \
 			 --upstream.service httpbin \
 			 --upstream.namespace my-namespace \
-			 --upstream.port 8080
+			 --upstream.port 8080 \
+			 --envoyfleet.name kusk-gateway-envoy-fleet
 	
 	This will fetch the OpenAPI document from the provided URL and generate a Kusk Gateway API resource
 	`,
@@ -137,9 +160,11 @@ var generateCmd = &cobra.Command{
 		}
 
 		if err := apiTemplate.Execute(os.Stdout, templates.APITemplateArgs{
-			Name:      name,
-			Namespace: namespace,
-			Spec:      strings.Split(apiSpec, "\n"),
+			Name:                name,
+			Namespace:           namespace,
+			EnvoyfleetName:      envoyFleetName,
+			EnvoyfleetNamespace: envoyFleetNamespace,
+			Spec:                strings.Split(apiSpec, "\n"),
 		}); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -232,6 +257,24 @@ func init() {
 		80,
 		"port of upstream service",
 	)
+
+	generateCmd.Flags().StringVarP(
+		&envoyFleetName,
+		"envoyfleet.name",
+		"",
+		"",
+		"name of envoyfleet to use for this API",
+	)
+	generateCmd.MarkFlagRequired("envoyfleet.name")
+
+	generateCmd.Flags().StringVarP(
+		&envoyFleetName,
+		"envoyfleet.namespace",
+		"",
+		"kusk-system",
+		"namespace of envoyfleet to use for this API. Default: kusk-system",
+	)
+
 
 	apiTemplate = template.Must(template.New("api").Parse(templates.APITemplate))
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -268,7 +268,7 @@ func init() {
 	generateCmd.MarkFlagRequired("envoyfleet.name")
 
 	generateCmd.Flags().StringVarP(
-		&envoyFleetName,
+		&envoyFleetNamespace,
 		"envoyfleet.namespace",
 		"",
 		"kusk-system",

--- a/templates/api.go
+++ b/templates/api.go
@@ -25,9 +25,11 @@ THE SOFTWARE.
 package templates
 
 type APITemplateArgs struct {
-	Name      string
-	Namespace string
-	Spec      []string
+	Name                string
+	Namespace           string
+	EnvoyfleetName      string
+	EnvoyfleetNamespace string
+	Spec                []string
 }
 
 var APITemplate = `
@@ -38,6 +40,9 @@ metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
 spec:
+  fleet:
+    name: {{ .EnvoyfleetName }}
+    namespace: {{ .EnvoyfleetNamespace }}
   spec: |
   {{- range $line := .Spec }}
     {{ $line -}}


### PR DESCRIPTION
This PR closes https://github.com/kubeshop/kusk-gateway/issues/332

## Changes

- add envoyfleet.name and envoyfleet.namespace flags to specify envoyfleet details which will expose the api the command it generating.
- envoyfleet name is required but envoyfleet namespace is not - defaults to kusk-system

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
