### PR TITLE
Pin `goreleaser` to version `v1.8.3`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,3 +24,13 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: test-GoReleaser-build
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: v1.8.3
+          args: release --rm-dist --skip-publish --skip-validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,7 +21,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: latest
+          version: v1.8.3
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}


### PR DESCRIPTION
This PR...

## Changes

- Pin `goreleaser` to version `v1.8.3`

## Fixes

- Nothing?

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
