### PR TITLE
Wait for docker image download and discard the output.

### DIFF
--- a/internal/mocking/server/server.go
+++ b/internal/mocking/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -42,8 +43,9 @@ func New(ctx context.Context, client *client.Client, configFile, apiToMock strin
 		return MockServer{}, fmt.Errorf("unable to pull mock server image: %w", err)
 	}
 
-	// Don't need the output so close it immediately
-	reader.Close()
+	// wait for download to complete, discard output
+	defer reader.Close()
+	io.Copy(io.Discard, reader)
 
 	return MockServer{
 		client:     client,


### PR DESCRIPTION
wait for docker image download and discard the output. Before when we were closing the reader straight away, this didn't wait for the download to complete. by consuming all the output from the ImagePull reader, once there is no more content, we can be confident that the download process is complete

This PR closes https://github.com/kubeshop/kusk-gateway/issues/552

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
