### PR TITLE
Separate handling of OpenAPI specification parsing and validating errors

### DIFF
--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -131,8 +131,12 @@ The mock server will return this exact response as its specified in an example:
 		}
 
 		spec, err := spec.NewParser(openapi3.NewLoader()).Parse(absoluteApiSpecPath)
-		if err != nil || spec.Validate(context.Background()) != nil {
-			ui.Fail(fmt.Errorf("unable to parse openapi config: %w", err))
+		if err != nil {
+			ui.Fail(fmt.Errorf("error when parsing openapi spec: %w", err))
+		}
+
+		if err := spec.Validate(context.Background()); err != nil {
+			ui.Fail(fmt.Errorf("openapi spec failed validation: %w", err))
 		}
 
 		ui.Info(ui.Green("🎉 successfully parsed OpenAPI spec"))


### PR DESCRIPTION
Separate handling of OpenAPI specification parsing and validating errors such that a nice error on what failed validation is returned to the user.

This PR closes https://github.com/kubeshop/kusk-gateway/issues/556

## Changes

- handle parsing errors and validating errors in separate blocks so appropriate errors are returned to the user

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Example
Given an API spec that is parseable but fails validation
```
openapi: 3.1.0
info:
  title: simple-api
  version: 0.4.0
paths:
  /statuscode/{code}:
    get:
      x-kusk:
        upstream:
          host:
            hostname: mocktarget.apigee.net
            port: 80
      parameters:
        - name: "code"
          in: "query"
          description: "Desired response status code."
          required: true
          schema:
            type: "string"
      responses:
        "200":
          description: "Success"
```

In the above example, the `{code}` path parameter is not properly specified in the parameters list

## Before
`⨯ unable to parse openapi config: %!w(<nil>) 💔`

## After
<img width="849" alt="Screenshot 2022-07-21 at 15 46 44" src="https://user-images.githubusercontent.com/6544380/180243528-983011b6-56f0-4e6e-81c6-4e953816f610.png">


